### PR TITLE
Improve HTTP status handling in _request()

### DIFF
--- a/pycupra/connection.py
+++ b/pycupra/connection.py
@@ -710,7 +710,7 @@ class Connection:
                     res = response
                 elif response.status == 200 and method==METH_DELETE:
                     res = response
-                elif response.status >= 200 or response.status <= 300:
+                elif 200 <= response.status <= 299:
                     # If this is a revoke token url, expect Content-Length 0 and return
                     if int(response.headers.get('Content-Length', 0)) == 0 and 'revoke' in url:
                         if response.status == 200:


### PR DESCRIPTION
Adjusted the success check in _request() to only treat valid 2xx responses as successful. The previous condition could include some unexpected status codes

The previous success check used:

```python
response.status >= 200 or response.status <= 300.
```

The OR makes this condition always true for any HTTP status code.
Every status is either >= 200 or <= 300, so the condition can never fail.
This caused 3xx redirects, 4xx client errors, and 5xx server errors to be treated as successful responses.

```python
200 <= response.status <= 299
```
uses a proper range check and ensures only real 2xx success codes are handled as successful.
